### PR TITLE
Se cambio el color de fondo del registro a uno más oscuro

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -61,7 +61,7 @@ const config: Config = {
           '5': 'hsl(var(--chart-5))',
         },
         // Aqui esta el color personalizado
-        'custom-green': '#00a73b', // verde tecmilenio (panel de registro)
+        'custom-green': '#00534c', // verde tecmilenio (panel de registro)
         'admin-blue': '#14095d', // azul oscuro (panel de administrador)
       },
       keyframes: {


### PR DESCRIPTION
Se cambio el color de fondo de registro a un verde mucho más oscuro, sin modificar los colores del panel de admi y el boton de registro